### PR TITLE
Support Boot 2.1.x App starters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ rebel.xml
 *.iml
 *.ipr
 *.iws
+.idea/

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,8 +58,10 @@ initializr:
           mappings:
           - versionRange: "[1.0.0.RELEASE,2.0.0.RELEASE)"
             version: 1.3.1.RELEASE
-          - versionRange: "[2.0.0.RELEASE,3.0.0.RELEASE)"
+          - versionRange: "[2.0.0.RELEASE,2.1.0.RELEASE)"
             version: 2.0.0.RELEASE
+          - versionRange: "[2.1.0.RELEASE,3.0.0.RELEASE)"
+            version: 2.1.0.BUILD-SNAPSHOT
             repositories: spring-snapshots,spring-milestones
       aggregate-counter-bom:
           groupId: org.springframework.cloud.stream.app


### PR DESCRIPTION
 - For boot 2.1+ inject boot-starter-web and boot-starter-actuator dependencies
 - Adjust the app-starters-core-dependencies version ranges to handle Boot 2.1

Resolves #12